### PR TITLE
removes forever-agent

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,9 +2,6 @@
 
 var request = require('request');
 var stream = require('stream-wrapper');
-var ForeverAgent = require('forever-agent');
-
-var agent = new ForeverAgent();
 
 module.exports = function(query, opts) {
 	if (!opts) opts = {};
@@ -24,7 +21,6 @@ module.exports = function(query, opts) {
 				marker: marker
 			},
 			json:true,
-			agent:opts.agent || agent
 		}, function(err, response) {
 			if (err) return self.emit('error', err);
 			if (!response.body.length) return self.push(null);

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "stream-wrapper": "~0.1.2",
     "request": "~2.27.0",
     "colors": "~0.6.2",
-    "forever-agent": "~0.5.0",
     "optimist": "~0.6.0",
     "osenv": "0.0.3"
   },


### PR DESCRIPTION
I was unable to run the CLI without this patch present; it'd throw

```
events.js:154
      throw er; // Unhandled 'error' event
      ^

Error: connect ENOENT /search.json?q=transform&u=noffle&marker=
    at Object.exports._errnoException (util.js:890:11)
    at exports._exceptionWithHostPort (util.js:913:20)
    at PipeConnectWrap.afterConnect [as oncomplete] (net.js:1065:14)
```

Even a simple program like

```
var Agent = require('forever-agent')
require('http').get({
  hostname: 'node-modules.com',
  port: 80,
  path: '/',
  agent: new Agent()
})
```

throws errors. I'm not positive what the underlying cause is, but connection pooling for a one-off CLI command probably doesn't seem that important anyway.
